### PR TITLE
FIX: Reduce number of post categories

### DIFF
--- a/melloc/posts/2022-02-08-mandelbrot-and-julia-sets/index.qmd
+++ b/melloc/posts/2022-02-08-mandelbrot-and-julia-sets/index.qmd
@@ -6,7 +6,7 @@ date: 2022-02-08
 abstract: >
   Fractals are a beautifully complex -- and I usually do not use these words together -- topic in Mathematics.
   This post scratches the theory behind with two well-know fractals.
-categories: [math, python]
+categories: [science, python]
 toc: true
 image: thumbnail.png  # https://cdn.pixabay.com/photo/2011/04/21/03/39/romanesco-6996_960_720.jpg
 ---

--- a/melloc/posts/2023-03-12-vscode-ipython-setup/index.qmd
+++ b/melloc/posts/2023-03-12-vscode-ipython-setup/index.qmd
@@ -6,7 +6,7 @@ date: 2023-03-12
 abstract: >
   Failing when working on something new is a given. Iterate quickly, fail fast.
   This post shows how IPython can change your workflow and how to set up it on VS Code.
-categories: [python]
+categories: [development, python]
 toc: true
 image: thumbnail.png
 ---

--- a/melloc/posts/2024-04-18-git-hooks-and-pre-commit/index.qmd
+++ b/melloc/posts/2024-04-18-git-hooks-and-pre-commit/index.qmd
@@ -6,7 +6,7 @@ date: 2024-04-18
 abstract: |
   pre-commit is a multi-language package manager for a set of Git hooks.
   It is a great tool for projects of any size, helping using and sharing hooks that check for code quality.
-categories: [programming]
+categories: [development]
 toc: true
 image: thumbnail.png
 ---

--- a/melloc/posts/2024-05-11-pre-commit-hooks-reference/index.qmd
+++ b/melloc/posts/2024-05-11-pre-commit-hooks-reference/index.qmd
@@ -4,7 +4,7 @@ subtitle: A reference guide to pre-commit hooks
 author: Gabriel Mello Silva
 date: 2024-05-11
 abstract: My selection of commonly used pre-commit hooks for different languages and tools.
-categories: [programming]
+categories: [development]
 toc: true
 image: thumbnail.png
 ---

--- a/melloc/posts/2025-08-25-streamlit-arborist/index.qmd
+++ b/melloc/posts/2025-08-25-streamlit-arborist/index.qmd
@@ -3,7 +3,7 @@ title: Announcing streamlit-arborist
 subtitle: Interactive tree view for Streamlit
 author: Gabriel Mello Silva
 date: 2025-08-25
-categories: [open-source, python, streamlit]
+categories: [open-source, python]
 toc: true
 image: thumbnail.png
 ---

--- a/melloc/posts/2026-06-23-richer-prompt/index.qmd
+++ b/melloc/posts/2026-06-23-richer-prompt/index.qmd
@@ -3,7 +3,7 @@ title: Announcing richer-prompt
 subtitle: Interactive terminal prompts for Python
 author: Gabriel Mello Silva
 date: 2026-06-23
-categories: [open-source, python, cli]
+categories: [open-source, python]
 toc: true
 image: thumbnail.png
 ---


### PR DESCRIPTION
## Changes

Reduced the number of post categories to:

- `open-source`: about my open-source projects
- `python`, `R`, etc: programming languages involved
- `development`: about software development tools and practices
- `science`: about sciences in general (Data Science, Math, Physics, etc)